### PR TITLE
molior-deploy: minimize lxd deployments per default

### DIFF
--- a/plugins/lxd.plugin
+++ b/plugins/lxd.plugin
@@ -4,6 +4,10 @@
 init_deployment_lxd()
 {
   init_deployment_dir
+  # Minimize per default, if not specified otherwise
+  if [ -z "$MINIMIZE" ]; then
+    MINIMIZE=1
+  fi
 }
 
 finalize_deployment_lxd()


### PR DESCRIPTION

This will not deploy man pages, package documentation and locales per default and greatly reduce the image size.

Signed-off-by: André Roth <neolynx@gmail.com>