### PR TITLE
molior-deploy: create empty machine-id file

### DIFF
--- a/initrd-installer/scripts/init-premount/installer
+++ b/initrd-installer/scripts/init-premount/installer
@@ -308,11 +308,6 @@ mount --bind /dev /mnt/target/dev
 mount --bind /sys /mnt/target/sys
 mount proc -t proc /mnt/target/proc
 
-if [ -x /mnt/target/bin/systemd-machine-id-setup ]; then
-  echo " * creating machine ID"
-  chroot /mnt/target systemd-machine-id-setup
-fi
-
 echo " * installing boot loader"
 if [ -n "$LINUX_CMDLINE" ]; then
   sed -i "s%^GRUB_CMDLINE_LINUX=.*$%GRUB_CMDLINE_LINUX=\"$LINUX_CMDLINE\"%" /mnt/target/etc/default/grub

--- a/molior-deploy
+++ b/molior-deploy
@@ -865,7 +865,7 @@ cleanup_deployment()
     rm -f $target/usr/bin/qemu-aarch64-static
   fi
   rm -f $target/etc/ssh/ssh_host_*
-  rm -f $target/etc/machine-id
+  echo -n > $target/etc/machine-id
   rm -f $target/var/lib/dbus/machine-id
 
   if [ -n "$MINIMIZE" ]; then


### PR DESCRIPTION
instead of creating the machine-id via initrd, place an
empty file which will be populated by systemd persistently.

Signed-off-by: André Roth <neolynx@gmail.com>