### PR TITLE
Make /usr/sbin/policy-rc.d configurable

### DIFF
--- a/molior-deploy
+++ b/molior-deploy
@@ -368,8 +368,8 @@ mount_bootstrap()
 while true; do
     case "\$1" in
       -*) shift ;;
-      makedev) exit 0;;
-      x11-common) exit 0;;
+      makedev|x11-common) exit 0;;
+      "${CHROOT_DAEMONS_ENABLED}") exit 0;;
       *) exit 101;;
     esac
 done


### PR DESCRIPTION
It allows to specify list of enabled daemons in chroot.
Daemons in a list are separated by "|".