### PR TITLE
molior-deploy: make SOURCE_DIR relocatable

### DIFF
--- a/molior-deploy
+++ b/molior-deploy
@@ -515,6 +515,7 @@ setup_deployment()
   log " * mirror: $MIRROR"
 
   if [ -n "$SOURCE_DIR" ]; then
+    SOURCE_DIR=`readlink -f $SOURCE_DIR`
     log " * using local package source: $SOURCE_DIR"
     cd $SOURCE_DIR
     REVISION=`dpkg-parsechangelog -S Version`+local


### PR DESCRIPTION
molior-deploy -s . can result in unwanted behavior, make
sure absolute paths are used internally

Signed-off-by: André Roth <neolynx@gmail.com>