### PR TITLE
molior-deploy: fix extendable policy-rc.d

### DIFF
--- a/molior-deploy
+++ b/molior-deploy
@@ -369,7 +369,13 @@ while true; do
     case "\$1" in
       -*) shift ;;
       makedev|x11-common) exit 0;;
-      ${CHROOT_DAEMONS_ENABLED}) exit 0;;
+EOM
+  if [ -n "$CHROOT_DAEMONS_ENABLED" ]; then
+  cat >> $target/usr/sbin/policy-rc.d <<EOM
+      $CHROOT_DAEMONS_ENABLED) exit 0;;
+EOM
+  fi
+  cat >> $target/usr/sbin/policy-rc.d <<EOM
       *) exit 101;;
     esac
 done


### PR DESCRIPTION
molior-deploy should not crash when CHROOT_DAEMONS_ENABLED is not set.

Signed-off-by: André Roth <neolynx@gmail.com>