### PR TITLE
Support custom deployment output's filename

### DIFF
--- a/molior-deploy
+++ b/molior-deploy
@@ -34,6 +34,7 @@ usage()
   echo "  -o OVERLAY_BASE   Specify overlay base and fetch top level package from there"
   echo "  -c                Cleanup on error (Default: ask)"
   echo "  -f                Build all variants (Default: ask)"
+  echo "  -F OUTPUT_FILE    Custom deployment output's filename"
   echo "  -d                Print debug output to stdout instead of file"
   echo "  -L                Keep log file"
   echo
@@ -48,7 +49,7 @@ usage()
 }
 
 origopts=$@
-while getopts "n:s:v:p:m:a:V:o:AlcfdOL" opt; do
+while getopts "n:s:v:p:m:a:V:o:F:AlcfdOL" opt; do
   case $opt in
     n)
       PACKAGE_NAME=$OPTARG
@@ -80,6 +81,10 @@ while getopts "n:s:v:p:m:a:V:o:AlcfdOL" opt; do
       ;;
     o)
       OVERLAY_VERSION=$OPTARG
+      shift 2
+      ;;
+    F)
+      DEPLOYMENT_OUTPUT_FILE=$OPTARG
       shift 2
       ;;
     O)
@@ -935,6 +940,19 @@ install_grub_bootloader()
 
   rm -rf $target/dev/disk/by-uuid
   umount_fs_devices
+}
+
+get_deployment_filename()
+{
+  EXTENSION="$1" 
+
+  if [ -z "$DEPLOYMENT_OUTPUT_FILE" ]
+  then
+    deployment="${PROJECT}_${VERSION}_${REVISION}_${VARIANT}.${EXTENSION}"
+  else
+    deployment="${DEPLOYMENT_OUTPUT_FILE}.${EXTENSION}"
+  fi
+  echo "$deployment"
 }
 
 # disable comflicting binfmts

--- a/plugins/dir.plugin
+++ b/plugins/dir.plugin
@@ -11,7 +11,7 @@ init_deployment_dir()
 
 finalize_deployment_dir()
 {
-  deployment=${PROJECT}_${VERSION}_${REVISION}.tar.xz
+  deployment=$(get_deployment_filename "tar.xz")
   echo " * creating $deployment"
   umount_bootstrap
   umount_fs

--- a/plugins/docker.plugin
+++ b/plugins/docker.plugin
@@ -29,7 +29,7 @@ finalize_deployment_docker()
   if [ $? -ne 0 ]; then
     log_error "Error running docker import"
   fi
-  deployment=${PROJECT}_${VERSION}_${REVISION}.docker
+  deployment=$(get_deployment_filename "docker")
   docker save  -o $deployment ${PROJECT}:${CONTAINER_VERSION} >&2
   if [ $? -ne 0 ]; then
     log_error "Error running docker save"

--- a/plugins/image.plugin
+++ b/plugins/image.plugin
@@ -9,7 +9,7 @@ preinit_deployment_image()
 init_deployment_image()
 {
   # FIXME: escape vars
-  imagename=${PROJECT}_${VERSION}_${REVISION}_$VARIANT.img
+  imagename==$(get_deployment_filename "img")
   echo " * creating $IMAGESIZE $WORK_DIR/$imagename"
   fallocate -l $IMAGESIZE $WORK_DIR/$imagename
 

--- a/plugins/info.plugin
+++ b/plugins/info.plugin
@@ -104,7 +104,7 @@ postinst_internal_deployment_info()
 
 finalize_deployment_info()
 {
-  deployment=${PROJECT}_${VERSION}_${REVISION}_$VARIANT.zip
+  deployment=$(get_deployment_filename "zip")
   echo " * creating $deployment"
   umount_bootstrap
   umount_fs

--- a/plugins/installer.plugin
+++ b/plugins/installer.plugin
@@ -190,7 +190,7 @@ EOF
     log_error "Error compressing $WORK_DIR/iso/image.cpio"
   fi
 
-  deployment=${PROJECT}_${VERSION}_${REVISION}_$VARIANT.iso
+  deployment=$(get_deployment_filename "iso")
   echo " * creating $deployment"
   rm -f $deployment
   VOLID=`printf "%.32s" "MLR:${PROJECT}"`

--- a/plugins/lxd.plugin
+++ b/plugins/lxd.plugin
@@ -12,7 +12,7 @@ init_deployment_lxd()
 
 finalize_deployment_lxd()
 {
-  deployment=${PROJECT}_${VERSION}_${REVISION}_${VARIANT}.tar.xz
+  deployment=$(get_deployment_filename "tar.xz")
   echo " * creating ${deployment}"
 
   umount_bootstrap

--- a/plugins/pxeinst.plugin
+++ b/plugins/pxeinst.plugin
@@ -78,7 +78,7 @@ EOF
     log_error "Error compressing $WORK_DIR/pxe/image.cpio"
   fi
 
-  deployment=${PROJECT}_${VERSION}_${REVISION}_$VARIANT.tar.xz
+  deployment=$(get_deployment_filename "tar.xz")
   echo " * creating $deployment"
   tar $TAR_PXZ -cf $WORK_DIR/${deployment} -C $WORK_DIR/pxe vmlinuz initrd.img image.cpio.xz README.md
   mv $WORK_DIR/${deployment} ./

--- a/plugins/upgrade.plugin
+++ b/plugins/upgrade.plugin
@@ -72,7 +72,7 @@ postinst_deployment_upgrade()
 
 finalize_deployment_upgrade()
 {
-  deployment=${PROJECT}_${VERSION}_${REVISION}_$VARIANT.tar.xz
+  deployment=$(get_deployment_filename "tar.xz")
   log " * creating Packages and Release files"
   mkdir -p $WORK_DIR/debian/dists/$PROJECT/$VERSION/stable/binary-$ARCH
   cd $WORK_DIR/debian

--- a/plugins/vbox.plugin
+++ b/plugins/vbox.plugin
@@ -20,7 +20,7 @@ preinit_deployment_vbox()
 
 init_deployment_vbox()
 {
-  vmname=${PROJECT}_${VERSION}_${REVISION}_${VARIANT}
+  vmname=$(get_deployment_filename "")
   #FIXME check VMSIZE
   echo " * creating ${VMSIZE}MB"
   if [ "$OLD_KERNEL" -eq 1 ]; then


### PR DESCRIPTION
You can either use an optional argument or the variable
'$DEPLOYMENT_OUTPUT_FILE' in a deployment's config to override default
deployment output's filename.