### PR TITLE
molior-deploy: add ability to layer the deployment

### DIFF
--- a/doc/molior-deploy.8.txt
+++ b/doc/molior-deploy.8.txt
@@ -3,6 +3,7 @@ NAME
 
 SYNOPSIS
  molior-deploy [OPTIONS] PROJECT VERSION
+ molior-deploy -b BASE_LAYER
 
 DESCRIPTION
  molior-deploy creates various types of deployments for molior projects. This is done by downloading the
@@ -44,6 +45,7 @@ OPTIONS
   -F OUTPUT_FILE    Custom deployment output's filename
   -d                Print debug output to stdout instead of file
   -L                Keep log file
+  -b BASE_LAYER     Use a base layer (rootfs) to create deployment from
 
 COMMON PARAMETERS
 
@@ -149,6 +151,10 @@ EXAMPLE
 	LVM_LV3_MNT=/opt
 	LVM_LV3_SIZE=16G
 	LVM_LV3_FS="ext4"
+
+  Create a deployment based on a previously created dir deployment (base layer):
+
+	$ sudo molior-deploy -b base-layer.tar.xz
 
 AUTHORS
  Please see the AUTHORS file in the source repositories.

--- a/molior-deploy
+++ b/molior-deploy
@@ -683,8 +683,10 @@ setup_deployment()
     ARCH=amd64
   fi
 
-  if [ -z "$INSTALL_PACKAGE" ]; then
-    INSTALL_PACKAGE=$PACKAGE_NAME-$VARIANT
+  if [ -z "$BASE_LAYER"]; then
+    if [ -z "$INSTALL_PACKAGE" ]; then
+      INSTALL_PACKAGE=$PACKAGE_NAME-$VARIANT
+    fi
   fi
 
   # FIXME: should be in bootstrap!?

--- a/molior-deploy
+++ b/molior-deploy
@@ -39,10 +39,11 @@ usage()
   echo "  -F OUTPUT_FILE    Custom deployment output's filename"
   echo "  -d                Print debug output to stdout instead of file"
   echo "  -L                Keep log file"
+  echo "  -b BASE_LAYER     Use a base layer (rootfs) to create deployment from"
   echo
   echo "Example:"
   echo "  $0 test 1.0"
-  echo "  $0 deployment.tar.xz"
+  echo "  $0 -b base-deployment.tar.xz"
   if [ -n "$1" ]; then
     echo
     echo $1
@@ -52,7 +53,7 @@ usage()
 }
 
 origopts=$@
-while getopts "n:s:v:p:m:a:V:o:F:AlcfdOL" opt; do
+while getopts "n:s:v:p:m:a:V:o:F:b:AlcfdOL" opt; do
   case $opt in
     n)
       PACKAGE_NAME=$OPTARG
@@ -88,6 +89,10 @@ while getopts "n:s:v:p:m:a:V:o:F:AlcfdOL" opt; do
       ;;
     F)
       DEPLOYMENT_OUTPUT_FILE=$OPTARG
+      shift 2
+      ;;
+    b)
+      BASE_LAYER=$OPTARG
       shift 2
       ;;
     O)
@@ -131,13 +136,15 @@ if [ $LIST_ONLY -eq 0 -a `id -u` -ne 0 ]; then
   usage "Please run $0 as root" >&2
 fi
 
-PROJECT=$1
-VERSION=$2
 
-if [ -f "$PROJECT" ]; then
-  BASE_LAYER="$PROJECT"
+if [ ! -z "$BASE_LAYER" ]; then
+  # use a base layer for the deployment
   VERSION="overlay"
 else
+  # bootstrap deployment from molior
+  PROJECT=$1
+  VERSION=$2
+
   if [ -z "$PROJECT" ]; then
     usage
   fi

--- a/molior-deploy
+++ b/molior-deploy
@@ -13,13 +13,15 @@ OVERLAY_VERSION=""
 OVERLAY_AUTO=0
 VARIANT="undefined"
 
+BASE_LAYER=""
+
 MOLIOR_TOOLS_VERSION=`cat /usr/lib/molior-tools/version`
 
 usage()
 {
   echo "molior-tools $MOLIOR_TOOLS_VERSION"
   echo
-  echo "Usage: $0 [OPTIONS] PROJECT VERSION"
+  echo "Usage: $0 [OPTIONS] PROJECT VERSION or $0 [OPTIONS] base-deployment.tar.xz"
   echo "Options:"
   echo "  -l                List deployment variants"
   echo "  -n PACKAGE_NAME   Package name (Default: PROJECT)"
@@ -40,6 +42,7 @@ usage()
   echo
   echo "Example:"
   echo "  $0 test 1.0"
+  echo "  $0 deployment.tar.xz"
   if [ -n "$1" ]; then
     echo
     echo $1
@@ -131,13 +134,19 @@ fi
 PROJECT=$1
 VERSION=$2
 
-if [ -z "$PROJECT" ]; then
-  usage
+if [ -f "$PROJECT" ]; then
+  BASE_LAYER="$PROJECT"
+  VERSION="overlay"
+else
+  if [ -z "$PROJECT" ]; then
+    usage
+  fi
+
+  if [ -z "$VERSION" ]; then
+    usage
+  fi
 fi
 
-if [ -z "$VERSION" ]; then
-  usage
-fi
 
 if [ "$deploy_all" -eq 1 ]; then
   opts=`echo $origopts | sed -e "s/$PROJECT//" -e "s/$VERSION//" -e 's/-f//'`
@@ -502,103 +511,109 @@ setup_deployment()
   log " * started: `date -R`"
   log " * logfile: $WORK_DIR/output.log"
 
-  if [ -z "$MOLIOR_PROJECTSOURCES_FILE" ]; then
-    log_info "Getting deployment information ..."
-    SOURCESURL=$MOLIOR_SERVER/api/projectsources/$PROJECT/$VERSION
-    APT_SOURCES_ORIG=`wget -q -O- $SOURCESURL`
-    if [ -z "$APT_SOURCES_ORIG" ]; then
-      log_error "Error downloading $SOURCESURL"
+  if [ -z "$BASE_LAYER" ]; then
+    if [ -z "$MOLIOR_PROJECTSOURCES_FILE" ]; then
+      log_info "Getting deployment information ..."
+      SOURCESURL=$MOLIOR_SERVER/api/projectsources/$PROJECT/$VERSION
+      APT_SOURCES_ORIG=`wget -q -O- $SOURCESURL`
+      if [ -z "$APT_SOURCES_ORIG" ]; then
+        log_error "Error downloading $SOURCESURL"
+      fi
+    else
+      log_info "Reading deployment information from $MOLIOR_PROJECTSOURCES_FILE ..."
+      APT_SOURCES_ORIG=`cat $MOLIOR_PROJECTSOURCES_FILE`
+      if [ -z "$APT_SOURCES_ORIG" ]; then
+        log_error "Error reading $MOLIOR_PROJECTSOURCES_FILE"
+      fi
     fi
-  else
-    log_info "Reading deployment information from $MOLIOR_PROJECTSOURCES_FILE ..."
-    APT_SOURCES_ORIG=`cat $MOLIOR_PROJECTSOURCES_FILE`
-    if [ -z "$APT_SOURCES_ORIG" ]; then
-      log_error "Error reading $MOLIOR_PROJECTSOURCES_FILE"
+    APT_SOURCES=`echo "$APT_SOURCES_ORIG" | sed '/^#/d'`
+    if [ "$APTLY_OVERRIDE" -eq 1 ]; then
+      APT_SOURCES=`echo "$APT_SOURCES" | sed "s=deb \([^:]\)\+://\([^/]\)\+=deb $APTLY_SERVER="`
     fi
-  fi
-  APT_SOURCES=`echo "$APT_SOURCES_ORIG" | sed '/^#/d'`
-  if [ "$APTLY_OVERRIDE" -eq 1 ]; then
-    APT_SOURCES=`echo "$APT_SOURCES" | sed "s=deb \([^:]\)\+://\([^/]\)\+=deb $APTLY_SERVER="`
-  fi
-  MIRROR=`echo "$APT_SOURCES" | head -n 1 | cut -d' ' -f 2`
-  if [ -z "$MIRROR" ]; then
-    log_error "No APT repo found"
-  fi
-  SUITE=`echo "$APT_SOURCES" | head -n 1 | cut -d' ' -f 3`
-  if [ -z "$SUITE" ]; then
-    log_error "No SUITE in APT repo found"
-  fi
-  tmp=`dirname $MIRROR`
-  REPOURL=`dirname $tmp`
-  BASEMIRROR=`basename $tmp`
-  BASEVERSION=`basename $MIRROR`
-  log " * mirror: $MIRROR"
+    MIRROR=`echo "$APT_SOURCES" | head -n 1 | cut -d' ' -f 2`
+    if [ -z "$MIRROR" ]; then
+      log_error "No APT repo found"
+    fi
+    SUITE=`echo "$APT_SOURCES" | head -n 1 | cut -d' ' -f 3`
+    if [ -z "$SUITE" ]; then
+      log_error "No SUITE in APT repo found"
+    fi
+    tmp=`dirname $MIRROR`
+    REPOURL=`dirname $tmp`
+    BASEMIRROR=`basename $tmp`
+    BASEVERSION=`basename $MIRROR`
+    log " * mirror: $MIRROR"
 
-  log_info "Getting source package ..."
-  if [ -n "$SOURCE_DIR" ]; then
-    SOURCE_DIR=`readlink -f $SOURCE_DIR`
-    log " * using local package source: $SOURCE_DIR"
-    cd $SOURCE_DIR
-    REVISION=`dpkg-parsechangelog -S Version`+local
-    log " * found source package: $PACKAGE_NAME $REVISION"
-    cd - >/dev/null
-  else
-    SOURCES_VERSION=$VERSION
-    if [ -n "$OVERLAY_VERSION" ]; then
-      SOURCES_VERSION=$OVERLAY_VERSION
-      log " * using overlay source: $SOURCES_VERSION"
-    fi
-    if [ "$OVERLAY_AUTO" -eq 1 ]; then
-      baseurls=`echo "$APT_SOURCES" | grep $MIRROR/repos/$PROJECT | awk '{print $2}'`
-      for baseurl in $baseurls
-      do
-        SOURCES_VERSION=`basename $baseurl`
-        log " * trying to download package source from $SOURCES_VERSION"
+    log_info "Getting source package ..."
+    if [ -n "$SOURCE_DIR" ]; then
+      SOURCE_DIR=`readlink -f $SOURCE_DIR`
+      log " * using local package source: $SOURCE_DIR"
+      cd $SOURCE_DIR
+      REVISION=`dpkg-parsechangelog -S Version`+local
+      log " * found source package: $PACKAGE_NAME $REVISION"
+      cd - >/dev/null
+    else
+      SOURCES_VERSION=$VERSION
+      if [ -n "$OVERLAY_VERSION" ]; then
+        SOURCES_VERSION=$OVERLAY_VERSION
+        log " * using overlay source: $SOURCES_VERSION"
+      fi
+      if [ "$OVERLAY_AUTO" -eq 1 ]; then
+        baseurls=`echo "$APT_SOURCES" | grep $MIRROR/repos/$PROJECT | awk '{print $2}'`
+        for baseurl in $baseurls
+        do
+          SOURCES_VERSION=`basename $baseurl`
+          log " * trying to download package source from $SOURCES_VERSION"
+          SOURCES=`wget -q -O- $MIRROR/repos/$PROJECT/$SOURCES_VERSION/dists/$DIST/main/source/Sources`
+          if [ -z "$SOURCES" ]; then
+            # try next baseurl
+            continue
+          fi
+          srcinfo=`echo "$SOURCES" | /usr/lib/molior-tools/find-latest-version.pl $PACKAGE_NAME $PACKAGE_VERSION`
+          if [ $? -ne 0 ]; then
+            # try next baseurl
+            continue
+          fi
+          FILENAME=`echo $srcinfo | cut -d ' ' -f 1`/`echo $srcinfo | cut -d ' ' -f 2`
+          REVISION=`echo $srcinfo | cut -d ' ' -f 3`
+          if [ -n "$FILENAME" ]; then
+            # found package
+            break
+          fi
+        done
+        if [ -z "$FILENAME" ]; then
+          log_error "No filename found for $PACKAGE_NAME in $MIRROR/repos/$PROJECT/$SOURCES_VERSION/dists/$DIST/main/source/Sources"
+        fi
+        log " * using package source: $SOURCES_VERSION"
+      else
         SOURCES=`wget -q -O- $MIRROR/repos/$PROJECT/$SOURCES_VERSION/dists/$DIST/main/source/Sources`
         if [ -z "$SOURCES" ]; then
-          # try next baseurl
-          continue
+          log_error "Could not download $MIRROR/repos/$PROJECT/$SOURCES_VERSION/dists/$DIST/main/source/Sources"
         fi
         srcinfo=`echo "$SOURCES" | /usr/lib/molior-tools/find-latest-version.pl $PACKAGE_NAME $PACKAGE_VERSION`
-        if [ $? -ne 0 ]; then
-          # try next baseurl
-          continue
-        fi
+        exit_on_error "Error searching $PACKAGE_NAME revision"
+
         FILENAME=`echo $srcinfo | cut -d ' ' -f 1`/`echo $srcinfo | cut -d ' ' -f 2`
         REVISION=`echo $srcinfo | cut -d ' ' -f 3`
-        if [ -n "$FILENAME" ]; then
-          # found package
-          break
+        if [ -z "$FILENAME" ]; then
+          log_error "No filename found for $PACKAGE_NAME in $MIRROR/repos/$PROJECT/$SOURCES_VERSION/dists/$DIST/main/source/Sources"
         fi
-      done
-      if [ -z "$FILENAME" ]; then
-        log_error "No filename found for $PACKAGE_NAME in $MIRROR/repos/$PROJECT/$SOURCES_VERSION/dists/$DIST/main/source/Sources"
       fi
-      log " * using package source: $SOURCES_VERSION"
-    else
-      SOURCES=`wget -q -O- $MIRROR/repos/$PROJECT/$SOURCES_VERSION/dists/$DIST/main/source/Sources`
-      if [ -z "$SOURCES" ]; then
-        log_error "Could not download $MIRROR/repos/$PROJECT/$SOURCES_VERSION/dists/$DIST/main/source/Sources"
-      fi
-      srcinfo=`echo "$SOURCES" | /usr/lib/molior-tools/find-latest-version.pl $PACKAGE_NAME $PACKAGE_VERSION`
-      exit_on_error "Error searching $PACKAGE_NAME revision"
 
-      FILENAME=`echo $srcinfo | cut -d ' ' -f 1`/`echo $srcinfo | cut -d ' ' -f 2`
-      REVISION=`echo $srcinfo | cut -d ' ' -f 3`
-      if [ -z "$FILENAME" ]; then
-        log_error "No filename found for $PACKAGE_NAME in $MIRROR/repos/$PROJECT/$SOURCES_VERSION/dists/$DIST/main/source/Sources"
-      fi
+      log " * downloading source: $MIRROR/repos/$PROJECT/$SOURCES_VERSION/$FILENAME"
+      cd $WORK_DIR
+      wget -q $MIRROR/repos/$PROJECT/$SOURCES_VERSION/$FILENAME
+      exit_on_error "Error downloading $MIRROR/repos/$PROJECT/$SOURCES_VERSION/$FILENAME"
+
+      tar xf `basename $FILENAME`
+      rm -f `basename $FILENAME`
+      cd - >/dev/null
+      SOURCE_DIR=$WORK_DIR/$PACKAGE_NAME
     fi
+  fi
 
-    log " * downloading source: $MIRROR/repos/$PROJECT/$SOURCES_VERSION/$FILENAME"
-    cd $WORK_DIR
-    wget -q $MIRROR/repos/$PROJECT/$SOURCES_VERSION/$FILENAME
-    exit_on_error "Error downloading $MIRROR/repos/$PROJECT/$SOURCES_VERSION/$FILENAME"
-
-    tar xf `basename $FILENAME`
-    rm -f `basename $FILENAME`
-    cd - >/dev/null
-    SOURCE_DIR=$WORK_DIR/$PACKAGE_NAME
+  if [ -z "$SOURCE_DIR" ]; then
+    log_error "SOURCE_DIR not set: use $0 -s SOURCE_DIR"
   fi
 
   if [ ! -d $SOURCE_DIR/deploy ]; then
@@ -694,68 +709,79 @@ bootstrap_deployment()
     fi
   fi
 
-  KEY_URL=$REPOURL/$PUBKEY_FILE
-  log " * importing gpg key from $KEY_URL"
+  if [ -z "$BASE_LAYER" ]; then
+    # start from scratch (no baselayer given)
 
-  include="gnupg"
-  eval t=\$DEBOOTSTRAP_INCLUDE_`echo $SUITE | tr '-' '_'`
-  if [ -n "$t" ]; then
-    include="$include,$t"
-  fi
+    KEY_URL=$REPOURL/$PUBKEY_FILE
+    log " * importing gpg key from $KEY_URL"
 
-  i=0
-  for url in $KEY_URL $APT_KEYS_EXTRA
-  do
-    if [ $i -ne 0 ]; then
-      postfix=".$i"
-    else
-      postfix=""
+    include="gnupg"
+    eval t=\$DEBOOTSTRAP_INCLUDE_`echo $SUITE | tr '-' '_'`
+    if [ -n "$t" ]; then
+      include="$include,$t"
     fi
-    i=$((i + 1))
-    wget -q $url -O $WORK_DIR/repo.asc$postfix
-    exit_on_error "Error downloading $url"
-  done
-  gpg -q --import --no-default-keyring --keyring=trustedkeys.gpg $WORK_DIR/repo.asc
 
-  echo " * downloading debootstrap for $SUITE $BASEMIRROR/$BASEVERSION $ARCH"
-  wget -q $MOLIOR_SERVER/debootstrap/${BASEMIRROR}_${BASEVERSION}_$ARCH.tar.xz -O $WORK_DIR/root.tar.xz
-  if [ $? -eq 0 ]; then
-    echo " * extracting debootstrap"
-    mkdir -p $target
-    cd $target
-    tar $TAR_PXZ -xf $WORK_DIR/root.tar.xz
-    cd - >/dev/null
-    rm -f $WORK_DIR/root.tar.xz
-    cp -f /etc/resolv.conf $target/etc/resolv.conf
-  else
-    echo " * error downloading debootstrap archive..."
-    echo " * running debootstrap for $SUITE $BASEMIRROR/$BASEVERSION $ARCH"
-
-    if echo $ARCH | grep -q arm; then
-      debootstrap --foreign --arch $ARCH --keyring=/root/.gnupg/trustedkeys.gpg --variant=minbase --include=$include $SUITE $target $MIRROR >&2
-      exit_on_error "debootstrap failed"
-      if [ "$ARCH" = "armhf" ]; then
-        cp /usr/bin/qemu-arm-static $target/usr/bin/
+    i=0
+    for url in $KEY_URL $APT_KEYS_EXTRA
+    do
+      if [ $i -ne 0 ]; then
+        postfix=".$i"
       else
-        cp /usr/bin/qemu-aarch64-static $target/usr/bin/
+        postfix=""
       fi
-      chroot $target /debootstrap/debootstrap --second-stage --no-check-gpg >&2
-      exit_on_error "debootstrap failed"
+      i=$((i + 1))
+      wget -q $url -O $WORK_DIR/repo.asc$postfix
+      exit_on_error "Error downloading $url"
+    done
+    gpg -q --import --no-default-keyring --keyring=trustedkeys.gpg $WORK_DIR/repo.asc
+
+    echo " * downloading debootstrap for $SUITE $BASEMIRROR/$BASEVERSION $ARCH"
+    wget -q $MOLIOR_SERVER/debootstrap/${BASEMIRROR}_${BASEVERSION}_$ARCH.tar.xz -O $WORK_DIR/root.tar.xz
+    if [ $? -eq 0 ]; then
+      echo " * extracting debootstrap"
+      mkdir -p $target
+      cd $target
+      tar $TAR_PXZ -xf $WORK_DIR/root.tar.xz
+      cd - >/dev/null
+      rm -f $WORK_DIR/root.tar.xz
+      cp -f /etc/resolv.conf $target/etc/resolv.conf
     else
-      debootstrap --arch $ARCH --keyring=/root/.gnupg/trustedkeys.gpg --variant=minbase --include=$include $SUITE $target $MIRROR >&2
-      exit_on_error "debootstrap failed"
-    fi
+      echo " * error downloading debootstrap archive..."
+      echo " * running debootstrap for $SUITE $BASEMIRROR/$BASEVERSION $ARCH"
 
-    if chroot $target dpkg -s tzdata > /dev/null 2>&1; then
-      # The package tzdata cannot be --excluded in debootstrap, so remove it here
-      # In order to use debconf for configuring the timezone, the tzdata package
-      # needs to be installer later as a dependency, i.e. after the config package
-      # preseeding debconf.
-      chroot $target apt-get purge --yes tzdata >&2
-      rm -f $target/etc/timezone
-    fi
+      if echo $ARCH | grep -q arm; then
+        debootstrap --foreign --arch $ARCH --keyring=/root/.gnupg/trustedkeys.gpg --variant=minbase --include=$include $SUITE $target $MIRROR >&2
+        exit_on_error "debootstrap failed"
+        if [ "$ARCH" = "armhf" ]; then
+          cp /usr/bin/qemu-arm-static $target/usr/bin/
+        else
+          cp /usr/bin/qemu-aarch64-static $target/usr/bin/
+        fi
+        chroot $target /debootstrap/debootstrap --second-stage --no-check-gpg >&2
+        exit_on_error "debootstrap failed"
+      else
+        debootstrap --arch $ARCH --keyring=/root/.gnupg/trustedkeys.gpg --variant=minbase --include=$include $SUITE $target $MIRROR >&2
+        exit_on_error "debootstrap failed"
+      fi
 
-    chroot $target apt-get clean >&2
+      if chroot $target dpkg -s tzdata > /dev/null 2>&1; then
+        # The package tzdata cannot be --excluded in debootstrap, so remove it here
+        # In order to use debconf for configuring the timezone, the tzdata package
+        # needs to be installer later as a dependency, i.e. after the config package
+        # preseeding debconf.
+        chroot $target apt-get purge --yes tzdata >&2
+        rm -f $target/etc/timezone
+      fi
+
+      chroot $target apt-get clean >&2
+    fi
+  else
+
+    # use the baselayer (has to be a dir deployment)
+    mkdir -p "$WORK_DIR/root"
+    tar -C $WORK_DIR/root -xf "$BASE_LAYER"
+    APT_SOURCES_ORIG="$(cat $WORK_DIR/root/etc/apt/sources.list)"
+
   fi
 
   if [ -n "$MINIMIZE" ]; then
@@ -802,11 +828,13 @@ EOF
     create_fstab
   fi
 
-  for key in $WORK_DIR/repo.asc*
-  do
-    chroot $target apt-key add - >/dev/null < $key
-    exit_on_error "Error adding apt key"
-  done
+  if [ -z "$BASE_LAYER" ]; then
+    for key in $WORK_DIR/repo.asc*
+    do
+      chroot $target apt-key add - >/dev/null < $key
+      exit_on_error "Error adding apt key"
+    done
+  fi
 
   echo "using nameservers:" >&2
   cat $target/etc/resolv.conf >&2


### PR DESCRIPTION
A deployment can now consist of multiple 'layers'
which means you can split configuration of the rootfs and
creating of the deployment (dir/installer/docker/lxd/...) itself.

```sh
# stage 1 (base layer)
molior-deploy -c base_dir PROJECT VERSION 
# output: base_dir.tar.xz

# stage 2 (actual deployment)
molior-deploy -c lxd_deployment -b base_dir.tar.xz
```