### PR TITLE
Feature/raid installer

### DIFF
--- a/doc/molior-deploy.8.txt
+++ b/doc/molior-deploy.8.txt
@@ -82,6 +82,14 @@ FILESYSTEM PARAMETERS
  LVM_LV#_OPTS       LVM logical volume # fstab options (i.e. "defaults,noatime")
  LVM_LV#_MKFSOPTS   Options for mkfs (i.e. "-O ^64bit,^metadata_csum")
 
+RAID PARAMETERS
+ Software RAID via the 'mdadm' may be created by defining the following parameters.
+ During the raid setup, all existing software raid devices are removed !
+
+ RAID_NAME          Set the raid device name (e.g. "/dev/md0")
+ RAID_DEVICES       List all physical drives/partitions for raid setup (e.g. "/dev/sda /dev/sdb")
+ RAID_OPTS          Specify all required options for the 'mdadm --create' command (e.g. "--level=1 --raid-devices=2 --metadata=1.0")
+
 BOOT PARAMETERS
  LINUX_CMDLINE      Set Linux command line options (i.e. "biosdevname=0 net.ifnames=0 init=/lib/systemd/systemd)
 

--- a/initrd-installer/hooks/installer
+++ b/initrd-installer/hooks/installer
@@ -23,6 +23,7 @@ copy_exec /sbin/sfdisk       /sbin/
 copy_exec /sbin/mkfs         /sbin/
 copy_exec /usr/sbin/chpasswd /sbin/
 copy_exec /usr/bin/eject     /sbin/
+copy_exec /sbin/wipefs       /sbin/
 
 # overwrite busybox binaries
 copy_exec /bin/cpio          /mbin/

--- a/initrd-installer/scripts/init-premount/installer
+++ b/initrd-installer/scripts/init-premount/installer
@@ -92,6 +92,8 @@ if [ -z "$SFDISK" ]; then
   log_error "Error: partitions not definded, please set \$SFDISK"
 fi
 
+create_raid
+
 if [ "$INSTALLER_USE_PXE" != "yes" ]; then
 
   # we are booting from usb, find the disk
@@ -310,7 +312,9 @@ if [ -n "$LVM_VG" ]; then
     vgremove -f "$vg" >&2
   done
 fi
-wipefs -a $disk
+if [ -z "$RAID_NAME" ]; then
+  wipefs -a $disk
+fi
 blockdev --rereadpt $disk
 
 create_partitions
@@ -381,6 +385,11 @@ echo -n -e "\033[1;m"
 
 create_fstab
 
+if [ -n "$RAID_NAME" ];then
+  # store raid configuration
+  mdadm --detail --scan >> /mnt/target/etc/mdadm/mdadm.conf
+fi
+
 mount --bind /dev /mnt/target/dev
 mount --bind /sys /mnt/target/sys
 mount proc -t proc /mnt/target/proc
@@ -401,7 +410,12 @@ if [ -n "$LINUX_CMDLINE" ]; then
 fi
 if [ "$TARGET_BOOTTYPE" = "efi" ]; then
   if modprobe efivars; then
-    chroot /mnt/target grub-install --recheck --force
+    if [ -n "$RAID_NAME" ]; then
+      # fix for grub-install error where efibootmgr complains about missing -d (disk) parameter
+      chroot /mnt/target grub-install --modules mdraid1x --recheck --force --removable
+    else
+      chroot /mnt/target grub-install --recheck --force
+    fi
   else # no EFI support in current boot mode
     chroot /mnt/target grub-install --recheck --force --target x86_64-efi
     mkdir -p /mnt/target/boot/efi/EFI/BOOT

--- a/initrd-installer/scripts/init-premount/installer
+++ b/initrd-installer/scripts/init-premount/installer
@@ -310,7 +310,7 @@ if [ -n "$LVM_VG" ]; then
     vgremove -f "$vg" >&2
   done
 fi
-dd if=/dev/zero of=$disk bs=512 count=1 2>/dev/null
+wipefs -a $disk
 blockdev --rereadpt $disk
 
 create_partitions

--- a/initrd-installer/scripts/init-premount/installer
+++ b/initrd-installer/scripts/init-premount/installer
@@ -422,7 +422,12 @@ if [ "$TARGET_BOOTTYPE" = "efi" ]; then
     mv /mnt/target/boot/efi/efi/debian/grubx64.efi /mnt/target/boot/efi/EFI/BOOT/bootx64.efi
   fi
 else
-  chroot /mnt/target grub-install --modules part_msdos --recheck --force --no-floppy $disk >/dev/null 2>&1
+  if [ -n "$RAID_NAME" ]; then
+    echo "$(chroot /mnt/target grub-probe -t drive -d $RAID_NAME) $RAID_NAME" > /mnt/target/boot/grub/device.map
+    chroot /mnt/target grub-install --modules part_msdos --force --no-floppy $disk >/dev/null 2>&1
+  else
+    chroot /mnt/target grub-install --modules part_msdos --recheck --force --no-floppy $disk >/dev/null 2>&1
+  fi
 fi
 chroot /mnt/target update-grub
 

--- a/molior-deploy.sh.inc
+++ b/molior-deploy.sh.inc
@@ -272,10 +272,6 @@ create_luks()
 create_raid()
 {
   if [ -n "$RAID_NAME" ]; then
-    if [ -z "$RAID_DEVICES" ]; then
-      log_error "Error: RAID devices not definded, please set \$SRAID_DEVICES"
-    fi
-
     # remove all existing md raids
     raids=$(grep raid /proc/mdstat | grep -v "Personalities" | tr -d " " | cut -d":" -f1)
     for raid in $raids; do
@@ -420,6 +416,9 @@ get_fsinfo()
   fi
 
   if [ -n "$RAID_NAME" ]; then
+    if [ -z "$RAID_DEVICES" ]; then
+      log_error "Error: RAID devices not definded, please set \$SRAID_DEVICES"
+    fi
     fs_on_raid=1
   fi
 }

--- a/molior-deploy.sh.inc
+++ b/molior-deploy.sh.inc
@@ -290,7 +290,7 @@ make_fs()
 
   else # normal filesystems
     echo " * mkfs $part"
-    eval mkfs $opts -t $s $part >/dev/null
+    eval mkfs -t $s $opts $part >/dev/null
     exit_on_error "Error formatting partition $part as $s"
   fi
 }

--- a/molior-deploy.sh.inc
+++ b/molior-deploy.sh.inc
@@ -5,6 +5,7 @@ MAXPART=16
 fs_has_partitions=0
 fs_has_lvm=0
 fs_has_luks=0
+fs_on_raid=0
 
 exit_on_error()
 {
@@ -268,6 +269,45 @@ create_luks()
   exit_on_error "Error opening LUKS partition $part"
 }
 
+create_raid()
+{
+  if [ -n "$RAID_NAME" ]; then
+    if [ -z "$RAID_DEVICES" ]; then
+      log_error "Error: RAID devices not definded, please set \$SRAID_DEVICES"
+    fi
+
+    # remove all existing md raids
+    raids=$(grep raid /proc/mdstat | grep -v "Personalities" | tr -d " " | cut -d":" -f1)
+    for raid in $raids; do
+      echo "removing old raid $raid"
+      mdadm --stop $raid
+      mdadm --remove $raid || true
+    done
+
+    # cleanup disks
+    for rd in $RAID_DEVICES; do
+      wipefs -a $rd
+    done
+
+    # setup raid
+    echo "creating raid $RAID_NAME"
+    mdadm --create $RAID_OPTS $RAID_NAME $RAID_DEVICES
+
+    # wait for disk sync
+    echo "syncing raid disks"
+    while true; do
+      p=$(grep "resync" /proc/mdstat)
+      printf "\r %s" "$p"
+      if grep -q "resync" /proc/mdstat; then
+        sleep 1
+      else
+        break
+      fi
+    done
+    echo
+  fi
+}
+
 make_fs()
 {
   s=$1
@@ -377,6 +417,10 @@ get_fsinfo()
         break
       fi
     done
+  fi
+
+  if [ -n "$RAID_NAME" ]; then
+    fs_on_raid=1
   fi
 }
 
@@ -640,5 +684,8 @@ get_deploy_config()
   echo "INSTALLER_INSTALL_DISK=\"$INSTALLER_INSTALL_DISK\""
   echo "INSTALLER_EXTRA_MODULES=\"$INSTALLER_EXTRA_MODULES\""
   echo "PARTSEP=\"$PARTSEP\""
+  echo "RAID_NAME=\"$RAID_NAME\""
+  echo "RAID_DEVICES=\"$RAID_DEVICES\""
+  echo "RAID_OPTS=\"$RAID_OPTS\""
 }
 

--- a/plugins/installer.plugin
+++ b/plugins/installer.plugin
@@ -96,6 +96,9 @@ prepare_initrd_deployment()
   if [ "$fs_has_luks" -eq 1 ]; then
     INSTALLER_EXTRA_PACKAGES="$INSTALLER_EXTRA_PACKAGES cryptsetup"
   fi
+  if [ "$fs_on_raid" -eq 1 ]; then
+    INSTALLER_EXTRA_PACKAGES="$INSTALLER_EXTRA_PACKAGES mdadm"
+  fi
 
   if [ ! -d $WORK_DIR/instroot ]; then
     # in case of using a base roots, there is no instroot debootstrap left,


### PR DESCRIPTION
During the installer installation process, the raid device can be created. Then the partitioning and FS is created on that raid device instead of a single disk.

example: 
use variables below in your deploy configuration file to create a raid device
RAID_NAME="/dev/md0"
RAID_DEVICES="/dev/sda /dev/sdb"
RAID_OPTS="--level=1 --raid-devices=2 --metadata=1.0"

