### PR TITLE
Use tab completion to select deployments, when available

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Depends: ${perl:Depends}, ${misc:Depends}, ${python3:Depends},
   debootstrap, xz-utils, devscripts, equivs, curl, lsb-release,
   python3, python3-yaml, python3-click, jq, pxz | xz-utils (>= 5.2.4-1)
 Conflicts: debrilis, rlx3-devtools, molior-deploy
+Recommends: rlwrap
 Description: molior development and deployment tools
  Tools for creating debian package releases in git repositories
  and for creating deployments of molior projects.

--- a/molior-deploy
+++ b/molior-deploy
@@ -760,8 +760,18 @@ setup_deployment()
   if [ "$found_variant" -ne 1 ]; then
     while true
     do
-      /bin/echo -n -e "${color_ask}Q: Please choose a deployment variant:\n`echo $variants | tr ' ' '\n' | sed 's/^/ > /'`\nEnter variant: $color_reset"
-      read VARIANT
+
+      # Read deployment variant. Use tab-completion if available.
+      if type rlwrap > /dev/null; then
+        rlwrap_comp=$WORK_DIR/molior-deployments.list
+        echo $variants > $rlwrap_comp
+        VARIANT=$(rlwrap -S "Q: Please choose a deployment variant: " -pYellow -e '' -i --break-chars ' ' -f $rlwrap_comp -o cat)
+        rm -f $rlwrap_comp
+      else
+        /bin/echo -n -e "${color_ask}Q: Please choose a deployment variant:\n`echo $variants | tr ' ' '\n' | sed 's/^/ > /'`\nEnter variant: $color_reset"
+        read VARIANT
+      fi
+
       if [ -z "$VARIANT" ]; then
         log_warn "No deployment variant choosen, aborting ..."
         ask_cleanup=0


### PR DESCRIPTION
If `rlwrap` is availble, `molior-deploy` will present the user the choice of deployments like this, e.g.:
```
Q: Please choose a deployment variant: ## user presses <tab><tab>
blazer-demo-installer-dev      blazer-demo-vbox-test          onedesign-demo-vbox-dev
blazer-demo-installer-test     onedesign-demo-installer-dev   onedesign-demo-vbox-test
blazer-demo-vbox-dev           onedesign-demo-installer-test
```