### PR TITLE
Attempt apt-get with --download-only to recover from network issues

### DIFF
--- a/molior-deploy
+++ b/molior-deploy
@@ -260,6 +260,16 @@ fi
 set -x
 
 # functions
+apt_get_chroot_with_retry ()
+{
+    for i in seq 1 3; do
+        if chroot $target apt-get --download-only "$@"; then
+            break
+        fi
+    done
+    chroot $target apt-get "$@"
+}
+
 finish ()
 {
   endtime=$(date +"%s")
@@ -988,7 +998,7 @@ EOF
   exit_on_error "apt-get update failed"
 
   log "upgrading system"
-  chroot $target apt-get --yes dist-upgrade >&2
+  apt_get_chroot_with_retry --yes dist-upgrade >&2
   exit_on_error "apt-get dist-upgrade failed"
 
   if [ $base_only -eq 0 ]; then
@@ -1032,7 +1042,7 @@ install_deployment()
   fi
 
   log "installing: $INSTALL_PACKAGE"
-  DEBIAN_FRONTEND=noninteractive chroot $target apt-get install --no-install-recommends --yes $INSTALL_PACKAGE $APT_INSTALL_EXTRA >&2
+  DEBIAN_FRONTEND=noninteractive apt_get_chroot_with_retry install --no-install-recommends --yes $INSTALL_PACKAGE $APT_INSTALL_EXTRA >&2
   exit_on_error "Error installing software"
 
   chroot $target apt-get clean >&2
@@ -1502,4 +1512,3 @@ elif [ $deployment_only -eq 1 ]; then
 else
   workflow_deployment
 fi
-


### PR DESCRIPTION
This is a greedy workaround to minimize the impact of network issue during package download while building a deploy