### PR TITLE
create-release: workaround of git diff-files bug of older git versions

### DIFF
--- a/create-release
+++ b/create-release
@@ -52,7 +52,7 @@ fi
 
 cd "$(git rev-parse --show-toplevel)"
 
-if ! git diff-files --quiet || ! git diff-index --quiet --cached HEAD; then
+if ! git diff-files > /dev/null || ! git diff-index --cached HEAD > /dev/null; then
   log_error "you have uncommitted changes, please commit or stash them."
 fi
 


### PR DESCRIPTION
There is a bug in git diff-files --quiet returning exit-status=1 for some reasons regarding CRLF. see https://public-inbox.org/git/20170225153230.GA30565@mcrowe.com/T/ It is solved using /dev/null redirection instead of --quiet option