### PR TITLE
Make curl honor the ~/.netrc file

### DIFF
--- a/add-molior-repo
+++ b/add-molior-repo
@@ -29,7 +29,7 @@ add_molior_project()
     PROJECT="$1"
     VERSION="$2"
 
-    APT_SOURCES="$(curl -s --retry 10 $MOLIOR_URL/api/projectsources/$PROJECT/$VERSION)"
+    APT_SOURCES="$(curl -n -s --retry 10 $MOLIOR_URL/api/projectsources/$PROJECT/$VERSION)"
     if [ -z "$APT_SOURCES" ]
     then
         echo "Error downloading apt sources from '$MOLIOR_URL'"
@@ -48,7 +48,7 @@ add_molior_project()
     # add the repository key
     # get the apt url from the molior api
     APT_URL=$(echo $MIRROR | cut -d' ' -f 2 | cut -d/ -f 1-3)
-    curl -s --retry 10 $APT_URL/$PUBKEY_FILE | apt-key add - > /dev/null
+    curl -n -s --retry 10 $APT_URL/$PUBKEY_FILE | apt-key add - > /dev/null
 
     # remove the mirror from the apt sources
     APT_SOURCES=$(echo "${APT_SOURCES}" | tail -n +2)

--- a/molior-archive-sources
+++ b/molior-archive-sources
@@ -41,7 +41,7 @@ COOKIE_FILE=`mktemp`
 molior_session_call()
 {
   URL_PATH="$1" && shift
-  curl $MOLIOR_URL$URL_PATH -s --retry 10 \
+  curl $MOLIOR_URL$URL_PATH -n -s --retry 10 \
     --cookie "$COOKIE_FILE" \
     --cookie-jar "$COOKIE_FILE" $@
 }

--- a/molior-build-upload
+++ b/molior-build-upload
@@ -82,7 +82,7 @@ cat ~/.molior-token >> $tmptoken
 umask $old_umask
 errmsg=`mktemp`
 
-httpret=`echo $args | xargs curl -w "%{http_code}" -o $errmsg -H @$tmptoken $MOLIOR_SERVER/api2/project/$PROJECT/$VERSION/extbuild 2>/dev/null`
+httpret=`echo $args | xargs curl -n -w "%{http_code}" -o $errmsg -H @$tmptoken $MOLIOR_SERVER/api2/project/$PROJECT/$VERSION/extbuild 2>/dev/null`
 ret=$?
 rm -f $tmptoken
 if [ $ret -eq 0 -a $httpret != "201" ]; then

--- a/molior-deploy
+++ b/molior-deploy
@@ -635,10 +635,10 @@ setup_deployment()
     fi
     log_info "Getting deployment information ..."
     SOURCESURL=$MOLIOR_SERVER/api2/project/$PROJECT/$VERSION/aptsources
-    APT_SOURCES_ORIG=`curl -f -s --retry 10 $SOURCESURL$param`
+    APT_SOURCES_ORIG=`curl -n -f -s --retry 10 $SOURCESURL$param`
     if [ -z "$APT_SOURCES_ORIG" ]; then
       SOURCESURL=$MOLIOR_SERVER/api/projectsources/$PROJECT/$VERSION
-      APT_SOURCES_ORIG=`curl -f -s --retry 10 $SOURCESURL`
+      APT_SOURCES_ORIG=`curl -n -f -s --retry 10 $SOURCESURL`
       if [ -z "$APT_SOURCES_ORIG" ]; then
         log_error "Error downloading $SOURCESURL"
       fi
@@ -696,7 +696,7 @@ setup_deployment()
       do
         SOURCES_VERSION=`basename $baseurl`
         log "trying to download package source from $SOURCES_VERSION"
-        curl -f -s --retry 10 -o $WORK_DIR/Sources $SOURCEMIRROR/repos/$PROJECT/$SOURCES_VERSION/dists/$dist/main/source/Sources
+        curl -n -f -s --retry 10 -o $WORK_DIR/Sources $SOURCEMIRROR/repos/$PROJECT/$SOURCES_VERSION/dists/$dist/main/source/Sources
         if [ `wc -l $WORK_DIR/Sources 2>/dev/null | cut -d' ' -f1` -eq 0 ]; then
           # try next baseurl
           continue
@@ -718,7 +718,7 @@ setup_deployment()
       fi
       log "using package source: $SOURCES_VERSION"
     else
-      curl -f -s --retry 10 -o $WORK_DIR/Sources $SOURCEMIRROR/repos/$PROJECT/$SOURCES_VERSION/dists/$dist/main/source/Sources
+      curl -n -f -s --retry 10 -o $WORK_DIR/Sources $SOURCEMIRROR/repos/$PROJECT/$SOURCES_VERSION/dists/$dist/main/source/Sources
       # FIXME: check if exists...
       if [ `wc -l $WORK_DIR/Sources 2>/dev/null | cut -d' ' -f1` -eq 0 ]; then
         log_error "Could not download $SOURCEMIRROR/repos/$PROJECT/$SOURCES_VERSION/dists/$dist/main/source/Sources"
@@ -735,7 +735,7 @@ setup_deployment()
 
     log "downloading source: $SOURCEMIRROR/repos/$PROJECT/$SOURCES_VERSION/$FILENAME"
     cd $WORK_DIR
-    curl -f -s --retry 10 -O -J $SOURCEMIRROR/repos/$PROJECT/$SOURCES_VERSION/$FILENAME
+    curl -n -f -s --retry 10 -O -J $SOURCEMIRROR/repos/$PROJECT/$SOURCES_VERSION/$FILENAME
     exit_on_error "Error downloading $SOURCEMIRROR/repos/$PROJECT/$SOURCES_VERSION/$FILENAME"
 
     if [ $src_pkg_only -eq 1 ]; then
@@ -908,13 +908,13 @@ bootstrap_deployment()
       postfix=""
     fi
     i=$((i + 1))
-    curl -f -s --retry 10 -o $WORK_DIR/repo.asc$postfix $url
+    curl -n -f -s --retry 10 -o $WORK_DIR/repo.asc$postfix $url
     exit_on_error "Error downloading $url"
   done
   gpg -q --import --no-default-keyring --keyring=trustedkeys.gpg $WORK_DIR/repo.asc
 
   log "downloading debootstrap for $SUITE $BASEMIRROR/$BASEVERSION $ARCH"
-  curl -f -s --retry 10 -o $WORK_DIR/root.tar.xz $MOLIOR_SERVER/debootstrap/${BASEMIRROR}_${BASEVERSION}_$ARCH.tar.xz
+  curl -n -f -s --retry 10 -o $WORK_DIR/root.tar.xz $MOLIOR_SERVER/debootstrap/${BASEMIRROR}_${BASEVERSION}_$ARCH.tar.xz
   if [ $? -eq 0 ]; then
     log "extracting debootstrap"
     mkdir -p $target

--- a/molior-project-manager
+++ b/molior-project-manager
@@ -268,7 +268,7 @@ COOKIE_FILE="$(mktemp)"
 molior_session_call()
 {
   URL_PATH="$1" && shift
-  curl $MOLIOR_URL$URL_PATH -s --retry 10 \
+  curl $MOLIOR_URL$URL_PATH -n -s --retry 10 \
     --cookie "$COOKIE_FILE" \
     --cookie-jar "$COOKIE_FILE" $@
 }

--- a/molior-sbuild
+++ b/molior-sbuild
@@ -142,7 +142,7 @@ PLATFORM=$(platform $ARCH)
 HOST_PLATFORM=$(platform $HOSTARCH)
 
 SOURCESURL=$MOLIOR_SERVER/api/projectsources/$PROJECT/$VERSION
-APT_SOURCES=`curl -s --retry 10 $SOURCESURL | grep -v '^#' | grep -v '^$'`
+APT_SOURCES=`curl -n -s --retry 10 $SOURCESURL | grep -v '^#' | grep -v '^$'`
 if [ $? -ne 0 ]; then
   log_error "Error downloading $SOURCESURL"
 fi
@@ -161,7 +161,7 @@ if ! schroot -i -c $SUITE-$ARCH-$VERSION >/dev/null 2>&1; then
   log_notice "Downloading schroot build environment"
 
   sudo mkdir -p /var/lib/schroot/chroots
-  sudo curl -s --retry 10 -o $SCHROOT $MOLIOR_SERVER/schroots/$SUITE-$VERSION-$ARCH.tar.xz
+  sudo curl -n -s --retry 10 -o $SCHROOT $MOLIOR_SERVER/schroots/$SUITE-$VERSION-$ARCH.tar.xz
   if [ $? -ne 0 ]; then
     log_error "Error downloading $MOLIOR_SERVER/schroots/$SUITE-$VERSION-$ARCH.tar.xz"
   fi

--- a/molior-trigger
+++ b/molior-trigger
@@ -33,7 +33,7 @@ COOKIE_FILE=`mktemp`
 
 molior_session_call()
 {
-  curl -s --retry 10 --cookie "$COOKIE_FILE" --cookie-jar "$COOKIE_FILE" "$@"
+  curl -n -s --retry 10 --cookie "$COOKIE_FILE" --cookie-jar "$COOKIE_FILE" "$@"
 }
 
 # login to the molior session
@@ -55,5 +55,5 @@ fi
 echo "Build triggered: $ID"
 echo
 echo "Query build state with: "
-echo "curl -s --retry 10 $MOLIOR_URL/api/build/$ID | json_pp"
+echo "curl -n -s --retry 10 $MOLIOR_URL/api/build/$ID | json_pp"
 echo

--- a/plugins/upgrade.plugin
+++ b/plugins/upgrade.plugin
@@ -31,7 +31,7 @@ init_deployment_upgrade()
   fi
   log_info "Getting deployment information ..."
   SOURCESURL=$MOLIOR_SERVER/api2/project/$PROJECT/$VERSION/aptsources
-  APT_SOURCES_ORIG=`curl -f -s --retry 10 $SOURCESURL$param`
+  APT_SOURCES_ORIG=`curl -n -f -s --retry 10 $SOURCESURL$param`
   if [ -z "$APT_SOURCES_ORIG" ]; then
     log_error "Error downloading $SOURCESURL"
   fi
@@ -94,7 +94,7 @@ postinst_deployment_upgrade()
   fi
   log_info "Getting deployment information ..."
   SOURCESURL=$MOLIOR_SERVER/api2/project/$PROJECT/$VERSION/aptsources
-  APT_SOURCES_ORIG=`curl -f -s --retry 10 $SOURCESURL$param`
+  APT_SOURCES_ORIG=`curl -n -f -s --retry 10 $SOURCESURL$param`
   if [ -z "$APT_SOURCES_ORIG" ]; then
     log_error "Error downloading $SOURCESURL"
   fi
@@ -123,7 +123,7 @@ postinst_deployment_upgrade()
           postfix=""
         fi
         i=$((i + 1))
-        curl -s --retry 10 -o $WORK_DIR/repo.asc$postfix $url
+        curl -n -s --retry 10 -o $WORK_DIR/repo.asc$postfix $url
         exit_on_error "Error downloading $url"
       done
 


### PR DESCRIPTION
This PR adds the `-n` (i.e. `--netrc`) flag to all `curl` invocations across all molior-tools scripts.

With the `-n` flag present, `curl` will honor the presence of a `~/.netrc` file and will read the login information from there.

* if no `~/.netrc` is present, curl will silently ignore that and continue without authentication
* if `~/.netrc` is present, but no matching "machine" entry found, curl will silently ignore that and continue without authentication
* if `~/.netrc` is present and a matching "machine" entry is found, it will authenticate with the "username" + "password" specified there

This allows you:
* to use molior tools with a molior server / mirror which require authentication (e.g. `molior-deploy -m https://my.mirror.org ...`
* to use apt sources from a mirror which requires authentication (e.g. `molior -p /my/apt/mirror.list ...`)

See also:
https://everything.curl.dev/usingcurl/netrc