### PR TITLE
Feat: Add include_file function to copy files from source packages

### DIFF
--- a/doc/molior-deploy.8.txt
+++ b/doc/molior-deploy.8.txt
@@ -76,8 +76,8 @@ INCLUDE FILES
 
  include_deploy_conf DEPLOYCONF      List of source packages separated by space to download and source deploy/common.inc or file specified after column (:)
                                      (e.g. include_deploy_conf "my-package my-other-package:conf/script.inc)
- include_file FILEPACKAGE            Copy a file from a source package to the current project. FILEPACKAGE must be in the form "package:sourcefile" where
-                                     sourcefile will be copied to PROJECT/sourcefile
+ include_file FILEPACKAGE            Copy a file from a source package to the current project. FILEPACKAGE must be in the form "package:file" where
+                                     file will be copied to PROJECT/file
                                      (e.g. include_file my-package:etc/config.conf)
 
 DISK PARAMETERS

--- a/doc/molior-deploy.8.txt
+++ b/doc/molior-deploy.8.txt
@@ -76,6 +76,9 @@ INCLUDE FILES
 
  include_deploy_conf DEPLOYCONF      List of source packages separated by space to download and source deploy/common.inc or file specified after column (:)
                                      (e.g. include_deploy_conf "my-package my-other-package:conf/script.inc)
+ include_file FILEPACKAGE			 Copy a file from a source package to the current project. FILEPACKAGE must be in the form "package:sourcefile" where
+									 sourcefile will be copied to PROJECT/sourcefile
+									 (e.g. include_file my-package:etc/config.conf)
 
 DISK PARAMETERS
  Multiple disks can be used during the installation by defining the following parameters.

--- a/doc/molior-deploy.8.txt
+++ b/doc/molior-deploy.8.txt
@@ -76,9 +76,9 @@ INCLUDE FILES
 
  include_deploy_conf DEPLOYCONF      List of source packages separated by space to download and source deploy/common.inc or file specified after column (:)
                                      (e.g. include_deploy_conf "my-package my-other-package:conf/script.inc)
- include_file FILEPACKAGE			 Copy a file from a source package to the current project. FILEPACKAGE must be in the form "package:sourcefile" where
-									 sourcefile will be copied to PROJECT/sourcefile
-									 (e.g. include_file my-package:etc/config.conf)
+ include_file FILEPACKAGE            Copy a file from a source package to the current project. FILEPACKAGE must be in the form "package:sourcefile" where
+                                     sourcefile will be copied to PROJECT/sourcefile
+                                     (e.g. include_file my-package:etc/config.conf)
 
 DISK PARAMETERS
  Multiple disks can be used during the installation by defining the following parameters.

--- a/molior-deploy
+++ b/molior-deploy
@@ -693,8 +693,9 @@ include_package()
     eval SOURCE_DIR=\$orig_SOURCE_DIR_$deploy_conf_level
     deploy_conf_level=$((deploy_conf_level - 1))
   else
-    # Copy the file (for include_file)
-    cp $SOURCE_DIR/$source_file $WORK_DIR/$PROJECT/$source_file
+    # Copy the file (for include_file) to the initial source directory
+    cp $SOURCE_DIR/$source_file $orig_SOURCE_DIR_file_1/$source_file
+    eval SOURCE_DIR=\$orig_SOURCE_DIR_file_$include_file_level
     include_file_level=$((include_file_level - 1))
   fi
 

--- a/molior-deploy
+++ b/molior-deploy
@@ -621,7 +621,6 @@ include_package()
   local package=$1
   local mode=$2  # "deploy_conf" or "file"
 
-  # Update the corresponding global level variable
   if [ "$mode" = "deploy_conf" ]; then
     deploy_conf_level=$((deploy_conf_level + 1))
   else

--- a/molior-deploy
+++ b/molior-deploy
@@ -23,6 +23,7 @@ omit_local_suffix=0
 debug_mode=0
 docker_login_registries=""
 deploy_conf_level=0
+include_file_level=0
 
 MOLIOR_TOOLS_VERSION=`cat /usr/lib/molior-tools/version`
 
@@ -615,21 +616,30 @@ umount_bootstrap()
   fi
 }
 
-include_deploy_conf()
+include_package()
 {
-  deploy_conf=$1
+  local package=$1
+  local mode=$2  # "deploy_conf" or "file"
 
-  # allow recursive calls
-  deploy_conf_level=$((deploy_conf_level + 1))
-
-  if echo $deploy_conf | grep -q ":"; then
-    source_file=`echo $deploy_conf | cut -d: -f2`
-    deploy_conf=`echo $deploy_conf | cut -d: -f1`
+  # Update the corresponding global level variable
+  if [ "$mode" = "deploy_conf" ]; then
+    deploy_conf_level=$((deploy_conf_level + 1))
   else
+    include_file_level=$((include_file_level + 1))
+  fi
+
+  if echo $package | grep -q ":"; then
+    source_file=`echo $package | cut -d: -f2`
+    package=`echo $package | cut -d: -f1`
+  else
+    if [ "$mode" = "file" ]; then
+      log_error "include file '$package' must be in the form 'package:sourcefile'"
+      exit 1
+    fi
     source_file=deploy/common.inc
   fi
 
-  log "downloading deploy conf package: $deploy_conf"
+  log "downloading ${mode} package: $package"
 
   baseurls=`echo "$APT_SOURCES" | grep $SOURCEMIRROR/repos/ | awk '{print $2}'`
   for baseurl in $baseurls
@@ -638,49 +648,70 @@ include_deploy_conf()
     curl -n -f -s --retry 10 -o $WORK_DIR/Sources.func $baseurl/dists/$dist/main/source/Sources
     lines=`wc -l $WORK_DIR/Sources 2>/dev/null | cut -d' ' -f1`
     if [ -n "$lines" ] && [ "$lines" -eq 0 ]; then
-      # try next baseurl
       continue
     fi
-    srcinfo=`/usr/lib/molior-tools/find-latest-version.pl $deploy_conf < $WORK_DIR/Sources.func`
+    srcinfo=`/usr/lib/molior-tools/find-latest-version.pl $package < $WORK_DIR/Sources.func`
     if [ $? -ne 0 ]; then
-      # try next baseurl
       continue
     fi
-    CONFPKG_NAME=`echo $srcinfo | cut -d ' ' -f 1`/`echo $srcinfo | cut -d ' ' -f 2`
-    CONFPKG_REV=`echo $srcinfo | cut -d ' ' -f 3`
-    if [ -n "$CONFPKG_NAME" ]; then
-        FUNC_SOURCEMIRROR=$baseurl
-      # found package
+    PKG_NAME=`echo $srcinfo | cut -d ' ' -f 1`/`echo $srcinfo | cut -d ' ' -f 2`
+    PKG_REV=`echo $srcinfo | cut -d ' ' -f 3`
+    if [ -n "$PKG_NAME" ]; then
+      FUNC_SOURCEMIRROR=$baseurl
       break
     fi
   done
   rm -f $WORK_DIR/Sources.func
-  if [ -z "$CONFPKG_NAME" ]; then
-    log_error "Error finding '$deploy_conf' source package in apt sources"
+  if [ -z "$PKG_NAME" ]; then
+    log_error "Error finding '$package' source package in apt sources"
   fi
-  confdir=`mktemp -d $WORK_DIR/conf-XXXXX`
+
+  pkgdir=`mktemp -d $WORK_DIR/conf-XXXXX`
   old_dir=$PWD
-  cd $confdir
-  curl -n -f -s --retry 10 -O -J $FUNC_SOURCEMIRROR/$CONFPKG_NAME
-  exit_on_error "Error downloading $FUNC_SOURCEMIRROR/$CONFPKG_NAME"
+  cd $pkgdir
+  curl -n -f -s --retry 10 -O -J $FUNC_SOURCEMIRROR/$PKG_NAME
+  exit_on_error "Error downloading $FUNC_SOURCEMIRROR/$PKG_NAME"
 
-  tar xf `basename $CONFPKG_NAME`
-  exit_on_error "Error extracting `basename $CONFPKG_NAME`"
+  tar xf `basename $PKG_NAME`
+  exit_on_error "Error extracting `basename $PKG_NAME`"
+  rm -f `basename $PKG_NAME`
 
-  rm -f `basename $CONFPKG_NAME`
+  log "sourcing from $package ($PKG_REV): $source_file"
+  
+  # provide new SOURCE_DIR for pkg includes to work (recursively)
+  if [ "$mode" = "deploy_conf" ]; then
+    eval orig_SOURCE_DIR_deploy_conf_$deploy_conf_level=$SOURCE_DIR
+  else
+    eval orig_SOURCE_DIR_file_$include_file_level=$SOURCE_DIR
+  fi
 
-  log "sourcing from $deploy_conf ($CONFPKG_REV): $source_file"
-  # provide new SOURCE_DIR for conf pkg includes to work (recursively)
-  eval orig_SOURCE_DIR_$deploy_conf_level=$SOURCE_DIR
-  SOURCE_DIR=$confdir/$deploy_conf
-  cd `dirname $deploy_conf/$source_file`
-  . $SOURCE_DIR/$source_file
-  cd - >/dev/null
-  eval SOURCE_DIR=\$orig_SOURCE_DIR_$deploy_conf_level
+  SOURCE_DIR=$pkgdir/$package
+
+  if [ "$mode" = "source" ]; then
+    # Source the file (for deploy_conf)
+    cd `dirname $package/$source_file`
+    . $SOURCE_DIR/$source_file
+    cd - >/dev/null
+    eval SOURCE_DIR=\$orig_SOURCE_DIR_$deploy_conf_level
+    deploy_conf_level=$((deploy_conf_level - 1))
+  else
+    # Copy the file (for include_file)
+    cp $SOURCE_DIR/$source_file $WORK_DIR/$PROJECT/$source_file
+    include_file_level=$((include_file_level - 1))
+  fi
 
   cd $old_dir
-  rm -rf $confdir
-  deploy_conf_level=$((deploy_conf_level - 1))
+  rm -rf $pkgdir
+}
+
+include_deploy_conf()
+{
+  include_package "$1" "deploy_conf"
+}
+
+include_file()
+{
+  include_package "$1" "file" 
 }
 
 setup_deployment()

--- a/molior-deploy
+++ b/molior-deploy
@@ -694,7 +694,8 @@ include_package()
     deploy_conf_level=$((deploy_conf_level - 1))
   else
     # Copy the file (for include_file) to the initial source directory
-    cp $SOURCE_DIR/$source_file $orig_SOURCE_DIR_file_1/$source_file
+    eval orig_dir=\$orig_SOURCE_DIR_file_$include_file_level
+    cp $SOURCE_DIR/$source_file $orig_dir/$source_file
     eval SOURCE_DIR=\$orig_SOURCE_DIR_file_$include_file_level
     include_file_level=$((include_file_level - 1))
   fi

--- a/molior-deploy
+++ b/molior-deploy
@@ -686,8 +686,7 @@ include_package()
 
   SOURCE_DIR=$pkgdir/$package
 
-  if [ "$mode" = "source" ]; then
-    # Source the file (for deploy_conf)
+  if [ "$mode" = "deploy_conf" ]; then
     cd `dirname $package/$source_file`
     . $SOURCE_DIR/$source_file
     cd - >/dev/null


### PR DESCRIPTION
This merge request introduces a new include_file function. This function is analogous to the existing include_deploy_conf but serves a different purpose: instead of sourcing a script, it copies a specified file from a source package directly into the main project's root directory ($WORK_DIR/$PROJECT/).

Problem: Currently, there's no straightforward way to include arbitrary files from other source packages into the main project's build context if those files are not meant to be sourced as shell scripts. This became apparent when attempting to use a list of Docker images (e.g., images.lst) from a dependent source package. The build process requires this file to be present in the project root at build time to determine which Docker images to pull, but the existing include_deploy_conf is unsuitable for this as it executes the file.

Solution: The include_file function allows specifying a package:sourcefile argument. It will then download the source package, extract it, and copy the sourcefile to $WORK_DIR/$PROJECT/sourcefile. This makes the file available in the project's root for subsequent build steps.

Use Case Example: A project requires an images.lst file from a sub-package to identify necessary Docker images during the build. With include_file "my-sub-package:docker/images.lst", this list can be copied into the main project's root, allowing the build system to parse it and pull the required images.